### PR TITLE
Relax Nokogiri dependency upper version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,25 +16,26 @@ Next, install the gem.
 
 And then you can do things like this...
 
-    Copyscape.username = 'yourname'
-    Copyscape.api_key = 'abc123'
-    
-    # URL search
-    search = Copyscape.url_search("http://www.copyscape.com/example.html")
-    search.duplicate? # => true
-    search.count # => 81
-    search.duplicates.each do |duplicate|
-      puts duplicate['title']
-      puts duplicate['url']
-      puts duplicate['textsnippet']
-      puts duplicate['htmlsnippet']
-      puts duplicate['minwordsmatched']
-    end
-    
-    # Text search
-    search = Copyscape.text_search('This is some text I want to check for plagurism')
-    search.duplicate? # => false
-    
+```ruby
+Copyscape.username = 'yourname'
+Copyscape.api_key = 'abc123'
+
+# URL search
+search = Copyscape.url_search("http://www.copyscape.com/example.html")
+search.duplicate? # => true
+search.count # => 81
+search.duplicates.each do |duplicate|
+  puts duplicate['title']
+  puts duplicate['url']
+  puts duplicate['textsnippet']
+  puts duplicate['htmlsnippet']
+  puts duplicate['minwordsmatched']
+end
+
+# Text search
+search = Copyscape.text_search('This is some text I want to check for plagurism')
+search.duplicate? # => false
+```    
     
 Currently, there is no support in the gem for "private index" searching, though
 it would be pretty easy to add.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ And then you can do things like this...
     search.duplicate? # => true
     search.count # => 81
     search.duplicates.each do |duplicate|
-      puts duplciate['title']
+      puts duplicate['title']
       puts duplicate['url']
       puts duplicate['textsnippet']
       puts duplicate['htmlsnippet']

--- a/copyscape.gemspec
+++ b/copyscape.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact
   s.require_path = 'lib'
   
-  s.add_dependency("nokogiri", "~> 1.4.1")
+  s.add_dependency("nokogiri", "~> 1.5")
   s.add_dependency("httparty", ">= 0.8.1")
   s.add_development_dependency("rake", "0.8.7")
   s.add_development_dependency("shoulda-context")

--- a/lib/copyscape.rb
+++ b/lib/copyscape.rb
@@ -5,15 +5,15 @@ require 'copyscape/balance'
 require 'copyscape/version'
 
 module Copyscape
-  
+
   class << self
 
     attr_accessor :username, :api_key
-    
+
     def url_search(url)
       UrlSearch.new(url)
     end
-    
+
     def text_search(*prms)
       TextSearch.new(*prms)
     end
@@ -21,7 +21,7 @@ module Copyscape
     def balance(format)
       Balance.new(format)
     end
-    
+
   end
-   
+
 end

--- a/lib/copyscape/balance.rb
+++ b/lib/copyscape/balance.rb
@@ -1,7 +1,7 @@
 require 'copyscape/request_base'
 
 module Copyscape
-  
+
   class Balance < RequestBase
 
     def initialize(format = :xml, encoding = 'UTF-8')
@@ -10,5 +10,5 @@ module Copyscape
     end
 
   end
-  
+
 end

--- a/lib/copyscape/request_base.rb
+++ b/lib/copyscape/request_base.rb
@@ -2,14 +2,14 @@ require 'forwardable'
 require 'httparty'
 
 module Copyscape
-  
+
   class RequestBase
 
     include HTTParty
     base_uri 'http://www.copyscape.com/api'
 
     extend Forwardable
-    
+
     def_delegators :response, :duplicate_count, :duplicates, :duplicate?,
                    :count, :error, :error?, :query, :query_words, :raw_response
 
@@ -19,16 +19,16 @@ module Copyscape
       {:u => Copyscape.username,
        :k => Copyscape.api_key}
     end
-    
+
     def response
       raise "@response must be set" unless @response
       @response
     end
-    
+
     def get_response(params)
       self.class.get('/', :query => base_params.merge(params)).body
     end
-    
+
     def post_response(params)
       self.class.post('/', :body => base_params.merge(params)).body
     end
@@ -36,7 +36,7 @@ module Copyscape
     def get_response_balance(format)
       self.class.get("/?u=#{Copyscape.username}&k=#{Copyscape.api_key}&o=balance&f=#{format.to_s}").body
     end
-   
+
   end
-  
+
 end

--- a/lib/copyscape/response.rb
+++ b/lib/copyscape/response.rb
@@ -20,6 +20,20 @@ module Copyscape
       query_words.to_i if query_words
     end
 
+    def all_words_matched
+      all_words_matched = field('allwordsmatched')
+      all_words_matched.to_i if all_words_matched
+    end
+
+    def all_percent_matched
+      all_percent_matched = field('allpercentmatched')
+      all_percent_matched.to_i if all_percent_matched
+    end
+
+    def all_text_matched
+      field('alltextmatched')
+    end
+
     # Returns the number of duplicates
     def count
       count = field('count')

--- a/lib/copyscape/response.rb
+++ b/lib/copyscape/response.rb
@@ -1,7 +1,7 @@
 require 'nokogiri'
 
 module Copyscape
-  
+
   class Response
 
     attr_reader :raw_response
@@ -10,36 +10,36 @@ module Copyscape
       @raw_response = buffer
       @document = Nokogiri(buffer)
     end
-    
+
     def query
       field('query')
     end
-    
+
     def query_words
       query_words = field('querywords')
       query_words.to_i if query_words
     end
-  
+
     # Returns the number of duplicates
     def count
       count = field('count')
       count.to_i
     end
-    
+
     # Returns true if the response was an error
     def error?
       !!error
     end
-    
+
     def error
       field('error')
     end
-  
+
     # Returns true if there are one or more duplicates
     def duplicate?
       count > 0
     end
-  
+
     # Returns an array of all the results in the form of a hash:
     def duplicates
       @duplicates ||= [].tap do |r|
@@ -48,9 +48,9 @@ module Copyscape
         end
       end
     end
-    
+
     private
-    
+
     # Given a result xml element, return a hash of the values we're interested in.
     def result_to_hash(result)
       result.children.inject({}) do |hash, node|
@@ -59,12 +59,12 @@ module Copyscape
         hash
       end
     end
-    
+
     def field(name)
       node = @document.search(name).first
       node.text if node
     end
-    
+
   end
-  
+
 end

--- a/lib/copyscape/text_search.rb
+++ b/lib/copyscape/text_search.rb
@@ -1,7 +1,7 @@
 require 'copyscape/request_base'
 
 module Copyscape
-  
+
   class TextSearch < RequestBase
 
     def initialize(text, encoding = 'UTF-8')
@@ -10,5 +10,5 @@ module Copyscape
     end
 
   end
-  
+
 end

--- a/lib/copyscape/url_search.rb
+++ b/lib/copyscape/url_search.rb
@@ -1,14 +1,14 @@
 require 'copyscape/request_base'
 
 module Copyscape
-  
+
   class UrlSearch < RequestBase
-    
+
     def initialize(url)
       http_response = get_response(:o => 'csearch', :q => url)
       @response = Response.new(http_response)
     end
-    
+
   end
-  
+
 end


### PR DESCRIPTION
Allow all Nokogiri versions from 1.4 up to 2.
Staying at 1.4.x is breaking dependency from other gem, like cucumber-rails, that depends on 1.5 and up.